### PR TITLE
Fix compilation on new Zig versions

### DIFF
--- a/src/consumer/try_set.zig
+++ b/src/consumer/try_set.zig
@@ -31,7 +31,7 @@ pub fn TrySet(comptime R: type, comptime S: type, comptime T: type, comptime set
         }
 
         inline fn _set(state: S, value: R) T!void {
-            return @call(.{ .modifier = .always_inline }, set, .{ state, value });
+            return @call(.always_inline, set, .{ state, value });
         }
     };
 }

--- a/src/hermit/bomb.zig
+++ b/src/hermit/bomb.zig
@@ -49,11 +49,11 @@ pub fn Bomb(comptime R: type, comptime S: type, comptime pd_next: ProducerType(R
         }
 
         inline fn pd_n(pd_event: Pd.Event) Pd.Action {
-            return @call(.{ .modifier = .always_inline }, pd_next, .{pd_event});
+            return @call(.always_inline, pd_next, .{pd_event});
         }
 
         inline fn cs_n(cs_event: Cs.Event) Cs.Action {
-            return @call(.{ .modifier = .always_inline }, cs_next, .{cs_event});
+            return @call(.always_inline, cs_next, .{cs_event});
         }
 
         inline fn _init(pd_action: Pd.Action, cs_action: Cs.Action) Type.State {

--- a/src/hermit/hermit_type.zig
+++ b/src/hermit/hermit_type.zig
@@ -27,7 +27,7 @@ pub fn HermitType(comptime S: type, comptime T: type) type {
         pub inline fn run(state: State, comptime next: Next, comptime deinit: Deinit) Out {
             var a = Action._continue(state);
             defer deinit(a.state);
-            const a_i = .{ .modifier = .always_inline };
+            const a_i = .always_inline;
             while (a.value == null) a = @call(a_i, next, .{a.state});
             return a.value.?;
         }

--- a/src/producer/from_iterable.zig
+++ b/src/producer/from_iterable.zig
@@ -20,7 +20,8 @@ pub fn FromIterable(comptime S: type, comptime T: type, comptime U: type) type {
                     return Type.Action._break(_init(i, null));
                 }
             } else {
-                return Type.Action._continue(_init(i, &i.iterator()));
+                var it = i.iterator();
+                return Type.Action._continue(_init(i, &it));
             }
         }
 

--- a/src/producer/rev_slice.zig
+++ b/src/producer/rev_slice.zig
@@ -1,6 +1,6 @@
 const zignite = @import("../zignite.zig");
 const expect = @import("std").testing.expect;
-const ReverseIndex = @import("Reverse_index.zig").ReverseIndex;
+const ReverseIndex = @import("reverse_index.zig").ReverseIndex;
 
 test "revSlice" {
     {

--- a/src/zignite.zig
+++ b/src/zignite.zig
@@ -196,12 +196,12 @@ pub inline fn revSlice(comptime T: type, slice: []const T) RevSlice(T) {
     return .{ .producer = _RevSlice(T).init(slice) };
 }
 
-pub fn Zignite(comptime Producer: type) type {
+pub fn Zignite(comptime TProducer: type) type {
     return struct {
         producer: Producer,
 
         const Self = @This();
-        pub const Producer = Producer;
+        pub const Producer = TProducer;
         pub const Type = Producer.Type;
         pub const State = Producer.Type.State;
         pub const Out = Producer.Type.Out;


### PR DESCRIPTION
The latest Zig compiler versions have broken some of the code in this repo. Also, I found a case difference in an import resulting in failed Linux builds. With this PR, it compiles and passes all tests. I made no semantic changes compared to the original intent.

I have described each commit in some detail, so please read the messages for more info.